### PR TITLE
fixed bug in rmvDAG

### DIFF
--- a/R/pcalg.R
+++ b/R/pcalg.R
@@ -176,7 +176,7 @@ rmvDAG <-
     colnames(errMat) <- nodes(dag) # == colnames(weightMatrix)
 
   ## compute X matrix X_i
-  if (sum(weightMatrix) > 0) {
+  if (sum(abs(weightMatrix)) > 0) {
     X <- errMat
     for (j in 2:p) { ## uses X[*, 1:(j-1)] -- "recursively" !
       ij <- 1:(j-1)


### PR DESCRIPTION
Hi,

it seems that the current version of rmvDAG samples from the error matrix when the sum of all edge weights is not larger than 0. I don't think this is what we want. As a minimal example, assume we have two nodes, X and Y, where the edge X -> Y is -0.5. The current rmvDAG function would sample from the error matrix instead of accounting for this negative effect.

I have fixed this by writing sum(abs(weightMatrix)) > 0 instead of sum(weightMatrix) > 0.

Cheers,
Fabian